### PR TITLE
feat: add json-server chart with persistent storage

### DIFF
--- a/10-json-server/Chart.yaml
+++ b/10-json-server/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: json-server
+description: A json-server based test API deployment
+version: 0.0.1
+appVersion: "1.0.0"
+

--- a/10-json-server/fleet.yaml
+++ b/10-json-server/fleet.yaml
@@ -1,0 +1,20 @@
+defaultNamespace: json-server
+
+labels:
+  app: json-server
+
+helm:
+  releaseName: json-server
+  chart: ""
+  repo: ""
+  version: ""
+  force: false
+  timeoutSeconds: 0
+
+namespaceLabels:
+  managed-by: Fleet
+namespaceAnnotations:
+  fleet.cattle.io/managed: "true"
+
+paused: false
+

--- a/10-json-server/templates/configmap.yaml
+++ b/10-json-server/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: json-server-data-config
+  namespace: json-server
+data:
+  db.json: |
+    {
+      "posts": [
+        { "id": 1, "title": "json-server", "author": "typicode" }
+      ],
+      "comments": [
+        { "id": 1, "body": "some comment", "postId": 1 }
+      ],
+      "profile": { "name": "typicode" }
+    }

--- a/10-json-server/templates/deploy.yaml
+++ b/10-json-server/templates/deploy.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: json-server-arm64
+  namespace: json-server
+spec:
+  selector:
+    matchLabels:
+      app: json-server
+      arch: arm64
+  template:
+    metadata:
+      labels:
+        app: json-server
+        arch: arm64
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      initContainers:
+        - name: init-db
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /data
+              if [ ! -f /data/db.json ]; then
+                echo "Copying db.json from config to PVC...";
+                cp /config/db.json /data/db.json;
+              else
+                echo "db.json already exists in PVC, skipping copy.";
+              fi
+          volumeMounts:
+            - name: db-config
+              mountPath: /config
+            - name: db-data
+              mountPath: /data
+      containers:
+        - name: json-server
+          image: backplane/json-server@sha256:95c55695c19f2420540fd7fd09da2d5847c47a0bbcb073c8d07fc2c428050153
+          args:
+            - "/data/db.json"
+            - "--watch"
+            - "--port"
+            - "80"
+            - "--host"
+            - "0.0.0.0"
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "100m"
+            limits:
+              cpu: "500m"
+          volumeMounts:
+            - name: db-data
+              mountPath: /data
+      volumes:
+        - name: db-config
+          configMap:
+            name: json-server-data-config
+        - name: db-data
+          persistentVolumeClaim:
+            claimName: json-server-data-pvc
+

--- a/10-json-server/templates/hpa.yaml
+++ b/10-json-server/templates/hpa.yaml
@@ -1,0 +1,33 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: json-server-hpa-arm64
+  namespace: json-server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: json-server-arm64
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300  # Wait 5 minutes before scaling down
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+

--- a/10-json-server/templates/pvc.yaml
+++ b/10-json-server/templates/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: json-server-data-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 10Gi
+


### PR DESCRIPTION
This commit introduces a json-server chart that includes persistent storage using PVC, deployment, and a configmap for initial data. This allows the json-server to retain data across pod restarts.

feat(deploy.yaml): deploy json-server on arm64 architecture

feat(deploy.yaml): add CPU resource requests and limits to deployment

feat(hpa.yaml): configure HPA scaling behavior with scale-up and scale-down policies