### PR TITLE
refactor(fleet): consolidate namespace definitions and update depende…

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/cattle-system/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/cattle-system/fleet.yaml
@@ -1,1 +1,0 @@
-defaultNamespace: cattle-system

--- a/01-kube-system/02-seal-secrets-helper/cert-manager/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/cert-manager/fleet.yaml
@@ -1,1 +1,0 @@
-defaultNamespace: cattle-system

--- a/01-kube-system/02-seal-secrets-helper/cockroachdb/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/cockroachdb/fleet.yaml
@@ -1,1 +1,0 @@
-defaultNamespace: cockroachdb

--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -1,9 +1,9 @@
 labels:
-  app: secrets
+  app: seal-secrets-helper
 
 kustomize:
   # To use a kustomization.yaml different from the one in the root folder
-  dir: "seal-secrets"
+  dir: "."
 
 # Optional: Configuration if you need to apply specific labels or annotations to the namespace
 namespaceLabels:
@@ -21,4 +21,4 @@ rolloutStrategy:
 dependsOn:
   - selector:
     matchLabels:
-      app: seal-secrets-helper
+      app: seal-secrets

--- a/01-kube-system/02-seal-secrets-helper/kustomization.yaml
+++ b/01-kube-system/02-seal-secrets-helper/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- namespaces.yaml

--- a/01-kube-system/02-seal-secrets-helper/monitoring/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/monitoring/fleet.yaml
@@ -1,1 +1,0 @@
-defaultNamespace: monitoring

--- a/01-kube-system/02-seal-secrets-helper/namespaces.yaml
+++ b/01-kube-system/02-seal-secrets-helper/namespaces.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/01-kube-system/02-seal-secrets-helper/traefik/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/traefik/fleet.yaml
@@ -1,1 +1,0 @@
-defaultNamespace: traefik


### PR DESCRIPTION
…ncies for seal-secrets-helper

This commit refactors the Fleet configuration for the `seal-secrets-helper` by:

- Removing individual `fleet.yaml` files for specific namespaces (`cattle-system`, `cert-manager`, `cockroachdb`, `monitoring`, `traefik`).
- Introducing a new top-level `fleet.yaml` in the `01-kube-system/02-seal-secrets-helper` directory to manage the deployment of the `seal-secrets-helper`.
- Creating a `namespaces.yaml` file to define the necessary namespaces (`cattle-system`, `cert-manager`, `traefik`, `monitoring`) centrally.
- Updating the `kustomization.yaml` to include `namespaces.yaml` as a resource.
- Modifying the `fleet.yaml` in `02-secrets` to depend on `seal-secrets-helper` instead of `seal-secrets`.

These changes centralize the namespace management and streamline the deployment process for the `seal-secrets-helper` within the Fleet system.