### PR TITLE
chore(fleet.yaml): set defaultNamespace to kube-system for seal-secre…

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -1,3 +1,5 @@
+defaultNamespace: kube-system
+
 labels:
   app: seal-secrets-helper
 

--- a/01-kube-system/02-seal-secrets-helper/namespaces.yaml
+++ b/01-kube-system/02-seal-secrets-helper/namespaces.yaml
@@ -3,10 +3,10 @@ kind: Namespace
 metadata:
   name: cattle-system
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-manager
+# apiVersion: v1
+# kind: Namespace
+# metadata:
+#   name: cert-manager
 ---
 apiVersion: v1
 kind: Namespace

--- a/02-secrets/fleet.yaml
+++ b/02-secrets/fleet.yaml
@@ -1,3 +1,5 @@
+defaultNamespace: kube-system
+
 labels:
   app: secrets
 


### PR DESCRIPTION
…ts-helper and secrets applications

This change ensures that both the seal-secrets-helper and secrets applications are deployed within the `kube-system` namespace by default. This is a common practice for system-level components and helps to centralize their management.