### PR TITLE
refactor(traefik): update apiVersion from traefik.containo.us/v1alpha…

### DIFF
--- a/05-traefik/traefik-helper/templates.ignore/rewrite-header-middleware.yaml
+++ b/05-traefik/traefik-helper/templates.ignore/rewrite-header-middleware.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
     name: rewrite-headers

--- a/05-traefik/traefik-helper/templates.ignore/test-ingress-route.yaml
+++ b/05-traefik/traefik-helper/templates.ignore/test-ingress-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: traefik-dashboard

--- a/05-traefik/traefik-helper/templates/ingress-route.yaml
+++ b/05-traefik/traefik-helper/templates/ingress-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: traefik-dashboard

--- a/05-traefik/traefik/middleware-auth.yaml
+++ b/05-traefik/traefik/middleware-auth.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: traefik-dashboard-basicauth

--- a/06-kubernetes-dashboard/kubernetes-dashboard-helper/templates/ingress-route.yaml
+++ b/06-kubernetes-dashboard/kubernetes-dashboard-helper/templates/ingress-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: kubernetes-dashboard

--- a/07-rancher/rancher-helper/templates/ingress-route.yaml
+++ b/07-rancher/rancher-helper/templates/ingress-route.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: rancher-tcp
@@ -16,7 +16,7 @@ spec:
     secretName: {{ .Values.cloudflare_zone_hyphen }}-tls
 
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: rancher

--- a/09-monitoring/monitoring-helper/templates/ingress-route.yaml
+++ b/09-monitoring/monitoring-helper/templates/ingress-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: monitoring-grafana


### PR DESCRIPTION
…1 to traefik.io/v1alpha1

The Traefik API group has been updated from `traefik.containo.us` to `traefik.io`. This change reflects the official domain for Traefik's Kubernetes resources and ensures compatibility with newer Traefik versions.