### PR TITLE
feat(fleet): add seal-secrets-helper dependency to fleet manifests

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/cattle-system/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/cattle-system/fleet.yaml
@@ -1,6 +1,17 @@
 defaultNamespace: cattle-system
 
+labels:
+  app: seal-secrets-helper
+
 namespaceLabels:
   managed-by: Fleet
 namespaceAnnotations:
   fleet.cattle.io/managed: "true"
+
+# This bundle just ensures the namespace exists
+# The actual sealed secrets are deployed by the 02-secrets bundle
+
+dependsOn:
+  - selector:
+      matchLabels:
+        app: seal-secrets

--- a/01-kube-system/02-seal-secrets-helper/monitoring/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/monitoring/fleet.yaml
@@ -1,7 +1,18 @@
 defaultNamespace: monitoring
 
+labels:
+  app: seal-secrets-helper
+
 namespaceLabels:
   managed-by: Fleet
 namespaceAnnotations:
   fleet.cattle.io/managed: "true"
+
+# This bundle just ensures the namespace exists
+# The actual sealed secrets are deployed by the 02-secrets bundle
+
+dependsOn:
+  - selector:
+      matchLabels:
+        app: seal-secrets
 

--- a/01-kube-system/02-seal-secrets-helper/traefik/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/traefik/fleet.yaml
@@ -1,7 +1,18 @@
 defaultNamespace: traefik
 
+labels:
+  app: seal-secrets-helper
+
 namespaceLabels:
   managed-by: Fleet
 namespaceAnnotations:
   fleet.cattle.io/managed: "true"
+
+# This bundle just ensures the namespace exists
+# The actual sealed secrets are deployed by the 02-secrets bundle
+
+dependsOn:
+  - selector:
+      matchLabels:
+        app: seal-secrets
 

--- a/02-secrets/fleet.yaml
+++ b/02-secrets/fleet.yaml
@@ -20,5 +20,8 @@ rolloutStrategy:
 
 dependsOn:
   - selector:
-    matchLabels:
-      app: seal-secrets
+      matchLabels:
+        app: seal-secrets
+  - selector:
+      matchLabels:
+        app: seal-secrets-helper


### PR DESCRIPTION
This change introduces a new dependency on the `seal-secrets-helper` for the `seal-secrets` bundle. This ensures that the `seal-secrets-helper` is deployed before the `seal-secrets` themselves, which is necessary for the correct functioning of the sealed secrets system.

The `seal-secrets-helper` is responsible for managing the namespaces where sealed secrets will be deployed. By adding this dependency, we ensure that these namespaces are created and managed correctly before the sealed secrets are applied. This change also adds labels to the `seal-secrets-helper` bundles to facilitate selection and management.