### PR TITLE
feat(fleet): add fleet.yaml for seal-secrets-helper

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -1,0 +1,8 @@
+# This is a multi-target Fleet configuration that creates namespace helper bundles
+# Each subdirectory (cattle-system, monitoring, traefik) will create its own bundle
+
+labels:
+  app: seal-secrets-helper
+
+# Fleet will automatically detect subdirectories with fleet.yaml files
+# and create separate bundles for each


### PR DESCRIPTION
This commit introduces a `fleet.yaml` file to the `seal-secrets-helper` directory. This configuration enables Fleet to manage the deployment of the seal-secrets-helper across different targets, as defined by its subdirectories. The `labels` section ensures proper identification and organization of these deployments within Fleet.