### PR TITLE
chore(fleet.yaml): set takeOwnership to false for seal-secrets-helper

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -25,6 +25,8 @@ helm:
   # is less that or equal to zero, we will not wait in Helm
   timeoutSeconds: 0
 
+  takeOwnership: false
+
 # Optional: Configuration if you need to apply specific labels or annotations to the namespace
 namespaceLabels:
   managed-by: Fleet


### PR DESCRIPTION
This change ensures that Fleet does not attempt to take ownership of the namespace where the seal-secrets-helper is deployed. This is a safer default behavior, preventing potential conflicts or unintended resource management by Fleet.