### PR TITLE
fix(fleet.yaml): add diff configuration to seal-secrets-helper to ens…

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -27,6 +27,30 @@ helm:
 
   takeOwnership: false
 
+diff:
+  comparePatches:
+  - apiVersion: v1
+    kind: Namespace
+    name: cattle-system
+    operations:
+    - {"op": "replace", "path": "/metadata/labels"}
+    - {"op": "replace", "path": "/metadata/annotations"}
+    - {"op": "replace", "path": "/metadata/managedFields"}
+  - apiVersion: v1
+    kind: Namespace
+    name: monitoring
+    operations:
+    - {"op": "replace", "path": "/metadata/labels"}
+    - {"op": "replace", "path": "/metadata/annotations"}
+    - {"op": "replace", "path": "/metadata/managedFields"}
+  - apiVersion: v1
+    kind: Namespace
+    name: traefik
+    operations:
+    - {"op": "replace", "path": "/metadata/labels"}
+    - {"op": "replace", "path": "/metadata/annotations"}
+    - {"op": "replace", "path": "/metadata/managedFields"}
+
 # Optional: Configuration if you need to apply specific labels or annotations to the namespace
 namespaceLabels:
   managed-by: Fleet


### PR DESCRIPTION
…ure correct namespace management

This change adds a `diff` section to the `fleet.yaml` file for the `seal-secrets-helper`. The purpose of this addition is to ensure that the labels, annotations, and managed fields of the `cattle-system`, `monitoring`, and `traefik` namespaces are correctly managed and updated. This prevents potential conflicts or unexpected behavior when applying changes through Fleet.