### PR TITLE
chore(fleet.yaml): simplify namespace operations to ignore changes in…

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -33,25 +33,17 @@ diff:
     kind: Namespace
     name: cattle-system
     operations:
-    - {"op": "replace", "path": "/metadata/labels"}
-    - {"op": "replace", "path": "/metadata/annotations"}
-    - {"op": "replace", "path": "/metadata/managedFields"}
+    - {"op":"ignore"}
   - apiVersion: v1
     kind: Namespace
     name: monitoring
     operations:
-    - {"op": "replace", "path": "/metadata/labels"}
-    - {"op": "replace", "path": "/metadata/annotations"}
-    - {"op": "replace", "path": "/metadata/managedFields"}
-    - {"op": "replace", "path": "/metadata/finalizers"}
-    - {"op": "replace", "path": "/spec/finalizers"}
+    - {"op":"ignore"}
   - apiVersion: v1
     kind: Namespace
     name: traefik
     operations:
-    - {"op": "replace", "path": "/metadata/labels"}
-    - {"op": "replace", "path": "/metadata/annotations"}
-    - {"op": "replace", "path": "/metadata/managedFields"}
+    - {"op":"ignore"}
 
 # Optional: Configuration if you need to apply specific labels or annotations to the namespace
 namespaceLabels:


### PR DESCRIPTION
… labels, annotations, and managedFields

This change simplifies the fleet.yaml configuration by changing the operations for namespaces from specific replacements to a general ignore. This is done because these fields are often managed by Kubernetes itself or other controllers, and attempting to replace them can lead to conflicts or unintended side effects. By ignoring these fields, we ensure that the seal-secrets-helper deployment is not affected by changes to these dynamic parts of the namespace definition.