### PR TITLE
fix(fleet.yaml): enable production mode for cert-manager-helper by de…

### DIFF
--- a/04-cert-manager/cert-manager-helper/fleet.yaml
+++ b/04-cert-manager/cert-manager-helper/fleet.yaml
@@ -27,7 +27,7 @@ helm:
   timeoutSeconds: 0
 
   values:
-    enable_production: false
+    enable_production: true
 
   valuesFrom:
   - secretKeyRef:


### PR DESCRIPTION
…fault

This change ensures that the cert-manager-helper is configured for production environments out of the box, simplifying deployment and reducing the likelihood of misconfiguration.