### PR TITLE
refactor(fleet.yaml): remove ignore operations and specify removals f…

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -25,25 +25,29 @@ helm:
   # is less that or equal to zero, we will not wait in Helm
   timeoutSeconds: 0
 
-  takeOwnership: false
-
 diff:
   comparePatches:
   - apiVersion: v1
     kind: Namespace
     name: cattle-system
     operations:
-    - {"op":"ignore"}
+    - {"op": "remove", "path": "/metadata/labels"}
+    - {"op": "remove", "path": "/metadata/annotations"}
+    - {"op": "remove", "path": "/metadata/managedFields"}
   - apiVersion: v1
     kind: Namespace
     name: monitoring
     operations:
-    - {"op":"ignore"}
+    - {"op": "remove", "path": "/metadata/labels"}
+    - {"op": "remove", "path": "/metadata/annotations"}
+    - {"op": "remove", "path": "/metadata/managedFields"}
   - apiVersion: v1
     kind: Namespace
     name: traefik
     operations:
-    - {"op":"ignore"}
+    - {"op": "remove", "path": "/metadata/labels"}
+    - {"op": "remove", "path": "/metadata/annotations"}
+    - {"op": "remove", "path": "/metadata/managedFields"}
 
 # Optional: Configuration if you need to apply specific labels or annotations to the namespace
 namespaceLabels:


### PR DESCRIPTION
…or namespaces

This change refactors the `fleet.yaml` file by replacing generic "ignore" operations with specific removal operations for labels, annotations, and managedFields within the `cattle-system`, `monitoring`, and `traefik` namespaces. This provides a more precise and explicit control over the desired state of these namespaces during fleet management, ensuring that unwanted metadata is consistently removed.