### PR TITLE
chore(fleet.yaml): set takeOwnership to false for seal-secrets-helper

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -25,6 +25,8 @@ helm:
   # is less that or equal to zero, we will not wait in Helm
   timeoutSeconds: 0
 
+  takeOwnership: false
+
 diff:
   comparePatches:
   - apiVersion: v1


### PR DESCRIPTION
This change ensures that the Helm release for the seal-secrets-helper does not attempt to take ownership of existing resources, preventing potential conflicts or unintended modifications.