### PR TITLE
refactor(fleet.yaml): simplify namespace operations to replace entire…

### DIFF
--- a/01-kube-system/02-seal-secrets-helper/fleet.yaml
+++ b/01-kube-system/02-seal-secrets-helper/fleet.yaml
@@ -33,23 +33,20 @@ diff:
     kind: Namespace
     name: cattle-system
     operations:
-    - {"op": "replace", "path": "/metadata/labels"}
-    - {"op": "replace", "path": "/metadata/annotations"}
-    - {"op": "replace", "path": "/metadata/managedFields"}
+    - {"op": "replace", "path": "/metadata"}
+    - {"op": "replace", "path": "/spec"}
   - apiVersion: v1
     kind: Namespace
     name: monitoring
     operations:
-    - {"op": "replace", "path": "/metadata/labels"}
-    - {"op": "replace", "path": "/metadata/annotations"}
-    - {"op": "replace", "path": "/metadata/managedFields"}
+    - {"op": "replace", "path": "/metadata"}
+    - {"op": "replace", "path": "/spec"}
   - apiVersion: v1
     kind: Namespace
     name: traefik
     operations:
-    - {"op": "replace", "path": "/metadata/labels"}
-    - {"op": "replace", "path": "/metadata/annotations"}
-    - {"op": "replace", "path": "/metadata/managedFields"}
+    - {"op": "replace", "path": "/metadata"}
+    - {"op": "replace", "path": "/spec"}
 
 # Optional: Configuration if you need to apply specific labels or annotations to the namespace
 namespaceLabels:


### PR DESCRIPTION
… metadata and spec sections

This change simplifies the fleet.yaml file by replacing the individual operations for labels, annotations, and managedFields with a single operation to replace the entire metadata and spec sections of the namespaces. This makes the configuration more concise and easier to manage.