### PR TITLE
feat(traefik): add namespace.yaml to create traefik namespace

### DIFF
--- a/05-traefik/traefik/kustomization.yaml
+++ b/05-traefik/traefik/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
+- namespace.yaml
 - middleware-auth.yaml

--- a/05-traefik/traefik/namespace.yaml
+++ b/05-traefik/traefik/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik


### PR DESCRIPTION
This commit introduces the `namespace.yaml` file to the Traefik configuration. This file defines a Kubernetes Namespace named `traefik`.

The primary reason for this change is to logically isolate Traefik resources within their own dedicated namespace. This improves organization, simplifies management, and prevents potential naming conflicts with other resources in the cluster.