### PR TITLE
refactor(traefik-prep): remove redundant namespace definition and lev…

### DIFF
--- a/05-traefik/traefik-prep/fleet.yaml
+++ b/05-traefik/traefik-prep/fleet.yaml
@@ -1,4 +1,5 @@
 defaultNamespace: traefik
+namespace: traefik
 
 labels:
   app: traefik-prep

--- a/05-traefik/traefik-prep/kustomization.yaml
+++ b/05-traefik/traefik-prep/kustomization.yaml
@@ -1,2 +1,1 @@
 resources:
-- namespace.yaml

--- a/05-traefik/traefik-prep/namespace.yaml
+++ b/05-traefik/traefik-prep/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: traefik


### PR DESCRIPTION
…erage fleet.yaml for namespace configuration

The `namespace.yaml` file is no longer necessary as the `namespace` field in `fleet.yaml` now handles the namespace configuration for the `traefik-prep` deployment. This change simplifies the Kubernetes manifests and centralizes namespace management.