### PR TITLE
refactor(fleet.yaml): remove unnecessary kustomization configuration …

### DIFF
--- a/05-traefik/traefik-prep/fleet.yaml
+++ b/05-traefik/traefik-prep/fleet.yaml
@@ -4,10 +4,6 @@ namespace: traefik
 labels:
   app: traefik-prep
 
-kustomize:
-  # To use a kustomization.yaml different from the one in the root folder
-  dir: ""
-
 # Optional: Configuration if you need to apply specific labels or annotations to the namespace
 namespaceLabels:
   managed-by: Fleet

--- a/05-traefik/traefik-prep/kustomization.yaml
+++ b/05-traefik/traefik-prep/kustomization.yaml
@@ -1,1 +1,0 @@
-resources:


### PR DESCRIPTION
…and delete unused kustomization.yaml file

The `kustomize.dir` field in `fleet.yaml` was not being used and was redundant. The corresponding `kustomization.yaml` file was also empty and therefore unnecessary. Removing these cleans up the configuration and removes unused files.