### PR TITLE
fix(monitoring): update grafana service name and helm release name to…

### DIFF
--- a/09-monitoring/monitoring-helper/templates/ingress-route.yaml
+++ b/09-monitoring/monitoring-helper/templates/ingress-route.yaml
@@ -12,7 +12,7 @@ spec:
     - match: Host(`grafana.{{ .Values.cloudflare_zone }}`)
       kind: Rule
       services:
-        - name: monitoring-grafana
+        - name: monitoring-stack-grafana
           port: 80
   tls:
     secretName: {{ .Values.cloudflare_zone_hyphen }}-tls

--- a/09-monitoring/monitoring/fleet.yaml
+++ b/09-monitoring/monitoring/fleet.yaml
@@ -8,7 +8,7 @@ helm:
   chart: kube-prometheus-stack
   repo: https://prometheus-community.github.io/helm-charts
   version: "77.11.0"  # (use the appropriate version)
-  releaseName: monitoring
+  releaseName: monitoring-stack
   valuesFiles:
     - values.yaml
   valuesFrom:


### PR DESCRIPTION
… monitoring-stack

This change ensures consistency in naming across the monitoring stack, specifically updating the Grafana service name in the ingress-route.yaml and the helm release name in fleet.yaml to 'monitoring-stack'. This resolves potential misconfigurations and improves clarity.