### PR TITLE
feat(wireguard): add helm chart for wireguard deployment

### DIFF
--- a/02-secrets/bundles/10-wireguard/wireguard/.gitignore
+++ b/02-secrets/bundles/10-wireguard/wireguard/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/10-wireguard/wireguard/Chart.yaml
+++ b/10-wireguard/wireguard/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: wireguard
+description: wireguard
+version: 0.0.0
+appVersion: 0.0.0
+

--- a/10-wireguard/wireguard/fleet.yaml
+++ b/10-wireguard/wireguard/fleet.yaml
@@ -1,0 +1,45 @@
+defaultNamespace: wireguard
+
+labels:
+  app: wireguard
+
+# Custom helm options
+helm:
+  # The release name to use. If empty a generated release name will be used
+  releaseName: wireguard
+
+  # The directory of the chart in the repo.  Also any valid go-getter supported
+  # URL can be used there is specify where to download the chart from.
+  # If repo below is set this value if the chart name in the repo
+  chart: ""
+
+  # An https to a valid Helm repository to download the chart from
+  repo: ""
+
+  # Used if repo is set to look up the version of the chart
+  version: ""
+
+  # Force recreate resource that can not be updated
+  force: false
+
+  # How long for helm to wait for the release to be active. If the value
+  # is less that or equal to zero, we will not wait in Helm
+  timeoutSeconds: 0
+
+  valuesFrom:
+  - secretKeyRef:
+      name: helper-values-secret
+      namespace: traefik
+      key: values.yaml
+
+    
+# Optional: Configuration if you need to apply specific labels or annotations to the namespace
+namespaceLabels:
+  managed-by: Fleet
+namespaceAnnotations:
+  fleet.cattle.io/managed: "true"
+
+# Optional: You might want to pause the rollout to manually inspect before deployment
+paused: false
+
+

--- a/10-wireguard/wireguard/templates/deploy.yaml
+++ b/10-wireguard/wireguard/templates/deploy.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: 
+    meta.helm.sh/release-name: wireguard
+  labels:
+  name: wireguard
+  namespace: wireguard
+spec:
+  selector:
+    matchLabels:
+      app: wireguard
+  template:
+    metadata:
+      labels:
+        app: wireguard
+    spec:
+      containers:
+      - env:
+        - name: TZ
+          value: Europe/Lisbon
+        - name: PEERS
+          value: user1,user2,user3
+        - name: PUID
+          value: "1000"
+        - name: PGID
+          value: "1000"
+        - name: ALLOWEDIPS
+          value: 0.0.0.0/0
+        - name: SERVERPORT
+          value: "51820" 
+        - name: SERVERURL
+          value: wireguard.{{ .Values.cloudflare_zone }}
+        image: linuxserver/wireguard:latest
+        name: wireguard
+        ports:
+        - containerPort: 51820
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_MODULE
+          privileged: true
+        volumeMounts:
+        - mountPath: "/config/"
+          name: wireguard-config
+      # imagePullSecrets:
+      # - name: docker-registry
+      initContainers:
+      - command:
+        - sh
+        - "-c"
+        - ENI=$(ip route get 8.8.8.8 | grep 8.8.8.8 | awk '{print $5}'); sed "s/ENI/$ENI/g"
+          /etc/wireguard-secret/wg0.conf.template > /config/wg0.conf; chmod 400 /config/wg0.conf
+        - sysctl -w net.ipv4.ip_forward=1
+        image: busybox
+        name: wireguard-template-replacement
+        volumeMounts:
+        - mountPath: "/config/"
+          name: wireguard-config
+        - mountPath: "/etc/wireguard-secret/"
+          name: wireguard-secret
+      volumes:
+      - name: wireguard-config
+        persistentVolumeClaim:
+          claimName: wireguard-config-pvc
+      - name: wireguard-secret
+        secret:
+          secretName: wireguard

--- a/10-wireguard/wireguard/templates/ingress.yaml
+++ b/10-wireguard/wireguard/templates/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: wireguard-udp
+  namespace: wireguard
+  annotations: 
+    kubernetes.io/ingress.class: traefik-external
+spec:
+  entryPoints:
+    - wireguard
+  routes:
+  - services:
+      - name: wireguard
+        port: 51820
+        weight: 10
+

--- a/10-wireguard/wireguard/templates/pvc.yaml
+++ b/10-wireguard/wireguard/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wireguard-config-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi

--- a/10-wireguard/wireguard/templates/service.yaml
+++ b/10-wireguard/wireguard/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wireguard
+spec:
+  type: NodePort
+  selector:
+    app: wireguard
+  ports:
+    - protocol: UDP
+      port: 51820
+      targetPort: 51820
+      nodePort: 32138


### PR DESCRIPTION
This commit introduces a new Helm chart for deploying WireGuard. The chart includes:

- A `Chart.yaml` file defining the chart's metadata.
- A `.gitignore` file to exclude unnecessary files.
- A `fleet.yaml` file for Fleet integration, specifying namespace and Helm options.
- A `deploy.yaml` file for the Kubernetes Deployment, configuring containers, environment variables, and volumes.
- An `ingress.yaml` file for Traefik UDP IngressRoute to expose WireGuard.
- A `pvc.yaml` file for a PersistentVolumeClaim to store WireGuard configuration.
- A `service.yaml` file for the Kubernetes Service to expose the WireGuard UDP port.

The deployment is configured to use the `linuxserver/wireguard` image and includes an init container to dynamically replace network interface names in the WireGuard configuration template. It also supports environment variables for peer configuration, user IDs, allowed IPs, server port, and server URL.