### PR TITLE
feat(fleet): add fleet.yaml for k8s-device-plugin deployment

### DIFF
--- a/11-k8s-device-plugin/fleet.yaml
+++ b/11-k8s-device-plugin/fleet.yaml
@@ -1,0 +1,30 @@
+defaultNamespace: k8s-device-plugin
+
+labels:
+  app: k8s-device-plugin
+
+helm:
+  repo: https://nvidia.github.io/k8s-device-plugin
+  chart: nvidia-device-plugin
+  version: 0.17.4
+  releaseName: nvidia-device-plugin
+
+  values:
+    gfd:
+      enabled: true
+    runtimeClassName: nvidia
+    sharing:
+      mps:
+        resources:
+        - name: nvidia.com/gpu
+          replicas: 10
+
+# Optional: Configuration if you need to apply specific labels or annotations to the namespace
+namespaceLabels:
+  managed-by: Fleet
+namespaceAnnotations:
+  fleet.cattle.io/managed: "true"
+
+# Optional: You might want to pause the rollout to manually inspect before deployment
+paused: false
+


### PR DESCRIPTION
This commit introduces a `fleet.yaml` file to manage the deployment of the NVIDIA Kubernetes device plugin using Fleet. This allows for declarative management of the device plugin, ensuring consistent deployments across clusters. The configuration includes specifying the namespace, Helm repository details, chart version, and enabling specific features like MPS for GPU sharing.