### PR TITLE
feat(jellyfin): add jellyfin helm chart and configuration

### DIFF
--- a/02-secrets/bundles/12-jellyfin/media-server/.gitignore
+++ b/02-secrets/bundles/12-jellyfin/media-server/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/02-secrets/templates/12-jellyfin/media-server/values-secret.yaml
+++ b/02-secrets/templates/12-jellyfin/media-server/values-secret.yaml
@@ -1,0 +1,10 @@
+# Jellyfin configuration
+jellyfin:
+  enableDLNA: false
+  env:
+    - name: JELLYFIN_PublishedServerUrl
+      value: "https://jellyfin.domain.com"
+    - name: NVIDIA_VISIBLE_DEVICES
+      value: "all"
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: "compute,video,utility"

--- a/04-cert-manager/cert-manager-helper/templates/certificate.yaml
+++ b/04-cert-manager/cert-manager-helper/templates/certificate.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: default
   annotations:
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cattle-system,plex"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cattle-system,media-server"
 spec:
   secretName: {{ .Values.cloudflare_zone_hyphen }}-tls
   issuerRef:

--- a/12-jellyfin/01-jellyfin/fleet.yaml
+++ b/12-jellyfin/01-jellyfin/fleet.yaml
@@ -1,0 +1,32 @@
+defaultNamespace: media-server
+
+labels:
+  app: jellyfin
+
+helm:
+  repo: https://jellyfin.github.io/jellyfin-helm
+  chart: jellyfin
+  version: "1.1.0"
+  releaseName: jellyfin
+
+  valuesFiles:
+    - values.yaml
+  valuesFrom:
+  - secretKeyRef:
+      name: values-secret
+      namespace: media-server
+      key: values.yaml
+
+
+kustomize:
+  # To use a kustomization.yaml different from the one in the root folder
+  dir: "storage"
+
+# Optional: Configuration if you need to apply specific labels or annotations to the namespace
+namespaceLabels:
+  managed-by: Fleet
+namespaceAnnotations:
+  fleet.cattle.io/managed: "true"
+
+# Optional: You might want to pause the rollout to manually inspect before deployment
+paused: false

--- a/12-jellyfin/01-jellyfin/storage/kustomization.yaml
+++ b/12-jellyfin/01-jellyfin/storage/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- storage-class.yaml 
+- pvc.yaml

--- a/12-jellyfin/01-jellyfin/storage/pvc.yaml
+++ b/12-jellyfin/01-jellyfin/storage/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: longhorn-jellyfin-storage
+  resources:
+    requests:
+      storage: 1500Gi

--- a/12-jellyfin/01-jellyfin/storage/storage-class.yaml
+++ b/12-jellyfin/01-jellyfin/storage/storage-class.yaml
@@ -1,0 +1,17 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-jellyfin-storage
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "2880"
+  fromBackup: ""
+  fsType: "ext4"
+  dataLocality: "best-effort"
+  nfsOptions: "vers=4.2,noresvport,softerr,timeo=600,retrans=5"
+  migratable: "false"
+  diskSelector: "storage.type=raid"

--- a/12-jellyfin/01-jellyfin/values.yaml
+++ b/12-jellyfin/01-jellyfin/values.yaml
@@ -1,0 +1,70 @@
+# Jellyfin image configuration
+image:
+  repository: docker.io/jellyfin/jellyfin
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# Use NVIDIA runtime for GPU acceleration
+runtimeClassName: nvidia
+
+# Resource configuration for GPU
+resources:
+  limits:
+    nvidia.com/gpu: 1
+  requests:
+    cpu: 1000m
+    memory: 2Gi
+
+# Storage configuration using Longhorn
+persistence:
+  config:
+    enabled: true
+    size: 10Gi
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+  media:
+    enabled: false  # We'll use external PVC
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 8096
+
+# Disable built-in ingress (using helper chart)
+ingress:
+  enabled: false
+
+# Security context
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+# Node selector and tolerations for GPU nodes
+nodeSelector: {}
+
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: nvidia.com/gpu.count
+              operator: Gt
+              values:
+                - '0'
+
+# Additional volume mounts for media
+volumeMounts:
+  - name: jellyfin-media
+    mountPath: /media
+
+# Additional volumes
+volumes:
+  - name: jellyfin-media
+    persistentVolumeClaim:
+      claimName: jellyfin-media

--- a/12-jellyfin/02-helpers/Chart.yaml
+++ b/12-jellyfin/02-helpers/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: jellyfin-helper
+description: helper chart for jellyfin ingress
+version: 0.0.0
+appVersion: 0.0.0

--- a/12-jellyfin/02-helpers/fleet.yaml
+++ b/12-jellyfin/02-helpers/fleet.yaml
@@ -1,0 +1,54 @@
+defaultNamespace: media-server
+
+labels:
+  app: jellyfin-helper
+
+# Custom helm options
+helm:
+  # The release name to use. If empty a generated release name will be used
+  releaseName: jellyfin-helper
+
+  # The directory of the chart in the repo.  Also any valid go-getter supported
+  # URL can be used there is specify where to download the chart from.
+  # If repo below is set this value if the chart name in the repo
+  chart: ""
+
+  # An https to a valid Helm repository to download the chart from
+  repo: ""
+
+  # Used if repo is set to look up the version of the chart
+  version: ""
+
+  # Force recreate resource that can not be updated
+  force: false
+
+  # How long for helm to wait for the release to be active. If the value
+  # is less that or equal to zero, we will not wait in Helm
+  timeoutSeconds: 0
+
+  valuesFiles:
+    - values.yaml
+  
+  valuesFrom:
+  - secretKeyRef:
+      name: helper-values-secret
+      namespace: traefik
+      key: values.yaml
+
+# Optional: Configuration if you need to apply specific labels or annotations to the namespace
+namespaceLabels:
+  managed-by: Fleet
+namespaceAnnotations:
+  fleet.cattle.io/managed: "true"
+
+# Optional: You might want to pause the rollout to manually inspect before deployment
+paused: false
+
+# Deployment strategy can be configured if needed (for larger or more complex deployments)
+rolloutStrategy:
+  maxUnavailable: 10%
+
+dependsOn:
+  - selector:
+    matchLabels:
+      app: jellyfin

--- a/12-jellyfin/02-helpers/templates/ingress.yaml
+++ b/12-jellyfin/02-helpers/templates/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: jellyfin-ingress
+  namespace: media-server
+  labels:
+  annotations:
+    kubernetes.io/ingress.class: traefik-external
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  entryPoints:
+    - websecure
+    - web
+  routes:
+    - match: Host(`jellyfin.{{ .Values.cloudflare_zone }}`)
+      kind: Rule
+      services:
+        - name: jellyfin
+          port: 8096
+  tls:
+    secretName: {{ .Values.cloudflare_zone_hyphen }}-tls

--- a/12-jellyfin/02-helpers/values.yaml
+++ b/12-jellyfin/02-helpers/values.yaml
@@ -1,0 +1,12 @@
+ingress:
+  # Specify if an ingress resource for the jellyfin server should be created or not
+  enabled: false
+
+  # The ingress class that should be used
+  ingressClassName: ""
+
+  # The url to use for the ingress reverse proxy to point at this jellyfin instance
+  url: ""
+
+  # Custom annotations to put on the ingress resource
+  annotations: {}

--- a/12-jellyfin/secrets/kustomization.yaml
+++ b/12-jellyfin/secrets/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- seal-secret-values-secret.yaml

--- a/12-jellyfin/secrets/seal-secret-values-secret.yaml
+++ b/12-jellyfin/secrets/seal-secret-values-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: values-secret
+  namespace: media-server
+spec:
+  encryptedData:
+    values.yaml: AgBuvezfGUIPEEqT1VRiNhG2a+hrWlJNVY/RqYw+/pFFhzdUdaj+M9F7kvj5PNsKbDkIGWYOAV9wmZ52WX1bgKCCRVL9ifOzqiUoRstY+7/ZihSx4YhHgzsPOrL/1ZuRjK0bA0T4/OzqzZfdbWXUiuGOno0ROGZrDDVxp+nm7u8c0hWeWFEFnN3i00v7OFwLgmajCRn/ds2wAD4cK7TDqBuD2ekezCF6Pj/ZFMOfbd8ndxPkyEKYSH1GYkBJxwLnrlIfKGI3O8WNE1/myHTR7+1wGjyFCGAr4AWkKUr3xHKj4pKzmK09EiPdRvSSUnzOaxF9T7pHAv2EPCijFFq7XdVOyl2wmn1SLuc7/KW/f7toAhEw0JBF+43ZXjq2tQyguok1ILaNVZMBGzzMpXdGtboGQtPkHtrJOYv78lUunrKxd96pYuwwKAGIuJ5XjiydEQiDgCnGk5YIC8Z1f9EB6t+M3wh8rFG4u/uNi71OLy60e9GBvJ9e5AWUMnDRNprH+X0pYziOqfS6eRWTwU7SyLeCfKcT/tNTWuIrAQTGxhV/WeqKF5yJIjHsjS0zN5EAeu9pd0ejrsGl96LpjmyrBBLYbskuilSsFrGEzP8tZrjp3o/zthR5PzkoTvRhBGFaxIWg4bDVror4y/XDzRb7nQ/wRuuBUunsT8KiJr72c2Av7hDIMj06m2hMWsskq9ghlraAkaj5beLSlVJ+FkOR5Fep0aVkhdIYbDGkVfFXIJ+u9iUHKK95rW77Bia5EjxuliLXY/fZ0HwvPym7ag9d9xYHfkgFelTrEqr+7e8jKlquIx0tCRXZQex0/KrA5GLMPJ+kU5swGBvGTxXhbwv8j2gUzXHbYA2cgOPoJUCqtFvk8HB+xRMu2Rbf1JnQ09yuMpbOY4nUdRDwHVftqPeXx2ajfOi8gLfknRKbMn+1SbIYlSVgEsAGnJSRVR+LZnKFnyXPN4sRhPo91GAAwnNKCj+KRIWNP2OP5T6dGk2mMN+RhXa2P701grzz+e5ZQ6M6mjmhaBM4Aqgc9z7GGY+UDuUPISshx0eE1W7gonQECqml9Qb7wfB6Qgu8
+  template:
+    metadata:
+      creationTimestamp: null
+      name: values-secret
+      namespace: media-server


### PR DESCRIPTION
This commit introduces the Jellyfin media server deployment using a Helm chart. It includes:
- A `.gitignore` file for the Jellyfin media server directory.
- A `values-secret.yaml` file for sensitive Jellyfin configuration.
- Updates to the `certificate.yaml` to include the `media-server` namespace.
- A `fleet.yaml` for deploying the Jellyfin Helm chart.
- Kustomize configuration for storage, including `storage-class.yaml` and `pvc.yaml`.
- A `values.yaml` file for the Jellyfin Helm chart, configuring image, resources, persistence, service, ingress, security context, and GPU node affinity.
- A helper chart (`Chart.yaml`, `fleet.yaml`, `templates/ingress.yaml`, `values.yaml`) for managing Jellyfin's ingress.
- A `kustomization.yaml` and `seal-secret-values-secret.yaml` for managing secrets.

The primary goal is to enable a robust and configurable Jellyfin deployment with GPU acceleration and persistent storage.