### PR TITLE
feat(fleet): add jellyfin secrets fleet configuration and dependency

### DIFF
--- a/12-jellyfin/01-jellyfin/fleet.yaml
+++ b/12-jellyfin/01-jellyfin/fleet.yaml
@@ -30,3 +30,8 @@ namespaceAnnotations:
 
 # Optional: You might want to pause the rollout to manually inspect before deployment
 paused: false
+
+dependsOn:
+  - selector:
+    matchLabels:
+      app: jellyfin-secrets

--- a/12-jellyfin/secrets/fleet.yaml
+++ b/12-jellyfin/secrets/fleet.yaml
@@ -1,0 +1,23 @@
+defaultNamespace: media-server
+
+labels:
+  app: jellyfin-secrets
+
+kustomize:
+  dir: ""
+
+# Optional: Configuration if you need to apply specific labels or annotations to the namespace
+namespaceLabels:
+  managed-by: Fleet
+namespaceAnnotations:
+  fleet.cattle.io/managed: "true"
+
+# Optional: You might want to pause the rollout to manually inspect before deployment
+paused: false
+
+dependsOn:
+  - selector:
+    matchLabels:
+      app: k8s-device-plugin
+
+


### PR DESCRIPTION
This commit introduces a new fleet configuration for jellyfin secrets and updates the existing jellyfin fleet configuration to include a dependency on the new secrets configuration. This ensures that the jellyfin application is deployed only after its secrets have been successfully applied.