### PR TITLE
feat(ingress.yaml): add TLS configuration for jellyfin ingress

### DIFF
--- a/12-jellyfin/02-helpers/templates/ingress.yaml
+++ b/12-jellyfin/02-helpers/templates/ingress.yaml
@@ -17,4 +17,6 @@ spec:
         - name: jellyfin
           port: 8096
   tls:
+    domains:
+    - main: jellyfin.{{ .Values.cloudflare_zone }}
     secretName: {{ .Values.cloudflare_zone_hyphen }}-tls


### PR DESCRIPTION
This change introduces TLS configuration to the ingress resource for Jellyfin. It specifies the domain for the TLS certificate using the `cloudflare_zone` value and references a Kubernetes secret for the certificate. This enables secure HTTPS access to the Jellyfin instance.