### PR TITLE
fix(ingress.yaml): update TLS configuration to include subdomain in S…

### DIFF
--- a/12-jellyfin/02-helpers/templates/ingress.yaml
+++ b/12-jellyfin/02-helpers/templates/ingress.yaml
@@ -18,5 +18,7 @@ spec:
           port: 8096
   tls:
     domains:
-    - main: jellyfin.{{ .Values.cloudflare_zone }}
+    - main: {{ .Values.cloudflare_zone }}
+      sans:
+      - jellyfin.{{ .Values.cloudflare_zone }}
     secretName: {{ .Values.cloudflare_zone_hyphen }}-tls


### PR DESCRIPTION
…ANs for proper certificate validation

The previous configuration only included the main domain in the TLS configuration, which could lead to certificate validation errors when accessing the Jellyfin service via its subdomain. This change adds the subdomain to the Subject Alternative Names (SANs) list, ensuring that the certificate is valid for both the main domain and the subdomain.