### PR TITLE
feat(cert-manager): add secretTemplate annotations to certificates fo…

### DIFF
--- a/04-cert-manager/cert-manager-helper/templates/certificate.yaml
+++ b/04-cert-manager/cert-manager-helper/templates/certificate.yaml
@@ -16,6 +16,10 @@ spec:
   dnsNames:
   - "{{ .Values.cloudflare_zone }}"
   - "*.{{ .Values.cloudflare_zone }}"
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cattle-system,media-server"
 
 ---
 apiVersion: cert-manager.io/v1
@@ -35,4 +39,8 @@ spec:
   dnsNames:
   - "local.{{ .Values.cloudflare_zone }}"
   - "*.local.{{ .Values.cloudflare_zone }}"
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kubernetes-dashboard,traefik"
 


### PR DESCRIPTION
…r reflection

This change adds annotations to the `secretTemplate` section of the `certificate.yaml` file. These annotations enable reflection for secrets generated by cert-manager, allowing them to be mirrored into specified namespaces. This is crucial for ensuring that secrets are accessible by other services that rely on them, such as those in `cattle-system`, `media-server`, `kubernetes-dashboard`, and `traefik` namespaces.