### PR TITLE
feat(cert-manager): enable automatic reflection for certificates

### DIFF
--- a/04-cert-manager/cert-manager-helper/templates/certificate.yaml
+++ b/04-cert-manager/cert-manager-helper/templates/certificate.yaml
@@ -20,6 +20,7 @@ spec:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cattle-system,media-server"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
 
 ---
 apiVersion: cert-manager.io/v1
@@ -43,4 +44,5 @@ spec:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kubernetes-dashboard,traefik"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
 


### PR DESCRIPTION
This change adds the `reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"` annotation to the `certificate.yaml` template. This enables automatic reflection of certificate resources, simplifying certificate management and ensuring that certificates are automatically propagated to the specified namespaces.